### PR TITLE
Add cliff to vesting

### DIFF
--- a/script/fuji/0_DeployProtocol.s.sol
+++ b/script/fuji/0_DeployProtocol.s.sol
@@ -191,49 +191,6 @@ contract DeployProtocolScript is Script {
             require(implementations.sMoe == address(sMoeImplementation), "run::7");
         }
 
-        // Deploy Vestings
-
-        {
-            VestingContract futureFundingVesting = new VestingContract(
-                proxies.masterChef,
-                IERC20(moeAddress),
-                Parameters.start + Parameters.futureFundingCliff,
-                Parameters.futureFundingDuration
-            );
-
-            require(vestings.futureFunding == address(futureFundingVesting), "run::12");
-        }
-
-        {
-            VestingContract teamVesting = new VestingContract(
-                proxies.masterChef, IERC20(moeAddress), Parameters.start + Parameters.teamCliff, Parameters.teamDuration
-            );
-
-            require(vestings.team == address(teamVesting), "run::13");
-        }
-
-        {
-            VestingContract seed1Vesting = new VestingContract(
-                proxies.masterChef,
-                IERC20(moeAddress),
-                Parameters.start + Parameters.seed1Cliff,
-                Parameters.seed1Duration
-            );
-
-            require(vestings.seed1 == address(seed1Vesting), "run::14");
-        }
-
-        {
-            VestingContract seed2Vesting = new VestingContract(
-                proxies.masterChef,
-                IERC20(moeAddress),
-                Parameters.start + Parameters.seed2Cliff,
-                Parameters.seed2Duration
-            );
-
-            require(vestings.seed2 == address(seed2Vesting), "run::15");
-        }
-
         // Deploy Proxies
 
         {

--- a/src/VestingContract.sol
+++ b/src/VestingContract.sol
@@ -12,10 +12,8 @@ import {IVestingContract} from "./interfaces/IVestingContract.sol";
  * and only the beneficiary can release the vested tokens.
  * The vesting contract can be revoked by the owner of the master chef contract.
  * The vesting schedule is as follows:
- * - vesting starts at the `start` timestamp
- * - no tokens can be claimed before the `start + lockDuration` timestamp
- * - all vested tokens can be claimed at the `start + duration` timestamp
- * -
+ * - tokens vest linearly from the `start` to the `start + vestingDuration` timestamp
+ * - vested tokens can only be claimed after the `start + lockDuration` timestamp
  */
 contract VestingContract is IVestingContract {
     using SafeERC20 for IERC20;

--- a/src/VestingContract.sol
+++ b/src/VestingContract.sol
@@ -10,6 +10,12 @@ import {IVestingContract} from "./interfaces/IVestingContract.sol";
  * @title Vesting Contract
  * @dev This contract implements a vesting contract. Only the owner of the master chef contract can set the beneficiary
  * and only the beneficiary can release the vested tokens.
+ * The vesting contract can be revoked by the owner of the master chef contract.
+ * The vesting schedule is as follows:
+ * - vesting starts at the `start` timestamp
+ * - no tokens can be claimed before the `start + lockDuration` timestamp
+ * - all vested tokens can be claimed at the `start + duration` timestamp
+ * -
  */
 contract VestingContract is IVestingContract {
     using SafeERC20 for IERC20;
@@ -18,7 +24,8 @@ contract VestingContract is IVestingContract {
 
     IERC20 private immutable _token;
     uint256 private immutable _start;
-    uint256 private immutable _duration;
+    uint256 private immutable _cliffDuration;
+    uint256 private immutable _vestingDuration;
 
     uint256 private _released;
 
@@ -30,13 +37,17 @@ contract VestingContract is IVestingContract {
      * @param masterChef_ The address of the master chef contract.
      * @param token_ The address of the token contract.
      * @param start_ The timestamp at which the vesting starts.
-     * @param duration_ The duration of the vesting.
+     * @param cliffDuration_ The duration of the lock.
+     * @param vestingDuration_ The duration of the vesting.
      */
-    constructor(address masterChef_, IERC20 token_, uint256 start_, uint256 duration_) {
+    constructor(address masterChef_, IERC20 token_, uint256 start_, uint256 cliffDuration_, uint256 vestingDuration_) {
+        if (cliffDuration_ > vestingDuration_) revert VestingContract__InvalidCliffDuration();
+
         _masterChef = masterChef_;
         _token = token_;
         _start = start_;
-        _duration = duration_;
+        _cliffDuration = cliffDuration_;
+        _vestingDuration = vestingDuration_;
     }
 
     /**
@@ -64,11 +75,19 @@ contract VestingContract is IVestingContract {
     }
 
     /**
+     * @dev Returns the duration of the lock.
+     * @return The duration of the lock.
+     */
+    function cliffDuration() public view virtual override returns (uint256) {
+        return _cliffDuration;
+    }
+
+    /**
      * @dev Returns the duration of the vesting.
      * @return The duration of the vesting.
      */
-    function duration() public view virtual override returns (uint256) {
-        return _duration;
+    function vestingDuration() public view virtual override returns (uint256) {
+        return _vestingDuration;
     }
 
     /**
@@ -76,7 +95,7 @@ contract VestingContract is IVestingContract {
      * @return The timestamp at which the vesting ends.
      */
     function end() public view virtual override returns (uint256) {
-        return _start + _duration;
+        return start() + vestingDuration();
     }
 
     /**
@@ -124,7 +143,7 @@ contract VestingContract is IVestingContract {
      * @dev Releases the vested tokens to the beneficiary.
      */
     function release() public virtual override {
-        if (msg.sender != _beneficiary) revert VestingContract__NotBeneficiary();
+        if (msg.sender != beneficiary()) revert VestingContract__NotBeneficiary();
 
         uint256 amount = releasable();
         _released += amount;
@@ -153,7 +172,7 @@ contract VestingContract is IVestingContract {
         address owner = Ownable(_masterChef).owner();
 
         if (msg.sender != owner) revert VestingContract__NotMasterChefOwner();
-        if (_revoked) revert VestingContract__AlreadyRevoked();
+        if (revoked()) revert VestingContract__AlreadyRevoked();
 
         uint256 released_ = released();
         uint256 balance = _token.balanceOf(address(this));
@@ -173,17 +192,18 @@ contract VestingContract is IVestingContract {
      * @return The amount of tokens that have been vested at the specified timestamp.
      */
     function _vestingSchedule(uint256 total, uint256 timestamp) internal view virtual returns (uint256) {
-        if (_revoked) return total;
+        if (revoked()) return total;
 
         uint256 start_ = start();
-        uint256 duration_ = duration();
+        uint256 cliffDuration_ = cliffDuration();
+        uint256 vestingDuration_ = vestingDuration();
 
-        if (timestamp <= start_) {
+        if (timestamp <= start_ + cliffDuration_) {
             return 0;
-        } else if (timestamp >= start_ + duration_) {
+        } else if (timestamp >= start_ + vestingDuration_) {
             return total;
         } else {
-            return (total * (timestamp - start_)) / duration_;
+            return (total * (timestamp - start_)) / vestingDuration_;
         }
     }
 }

--- a/src/VestingContract.sol
+++ b/src/VestingContract.sol
@@ -205,7 +205,7 @@ contract VestingContract is IVestingContract {
      * whether the vesting contract has a cliff or has been revoked.
      * @param total The total amount of tokens to be vested.
      * @param start_ The timestamp at which the vesting starts.
-     * @param vestingDuration_ The vestingDuration_ of the vesting.
+     * @param vestingDuration_ The duration of the vesting.
      * @param timestamp The timestamp at which the amount of vested tokens will be calculated.
      * @return The amount of tokens that have been vested at the specified timestamp.
      */

--- a/src/interfaces/IVestingContract.sol
+++ b/src/interfaces/IVestingContract.sol
@@ -7,6 +7,7 @@ interface IVestingContract {
     error VestingContract__NotBeneficiary();
     error VestingContract__NotMasterChefOwner();
     error VestingContract__AlreadyRevoked();
+    error VestingContract__InvalidCliffDuration();
 
     event BeneficiarySet(address beneficiary);
 
@@ -20,7 +21,9 @@ interface IVestingContract {
 
     function start() external view returns (uint256);
 
-    function duration() external view returns (uint256);
+    function cliffDuration() external view returns (uint256);
+
+    function vestingDuration() external view returns (uint256);
 
     function end() external view returns (uint256);
 

--- a/test/VestingContract.t.sol
+++ b/test/VestingContract.t.sol
@@ -14,10 +14,16 @@ contract VestingContractTest is Test {
 
     IERC20 token;
 
+    uint256 start = block.timestamp + 365 days;
+    uint256 cliffDuration = 10 days;
+    uint256 vestingDuration = 100 days;
+
+    uint256 total = 100e18;
+
     function setUp() public {
         token = new MockERC20("token", "TKN", 18);
 
-        vesting = new VestingContract(address(this), token, block.timestamp + 365 days, 365 days);
+        vesting = new VestingContract(address(this), token, start, cliffDuration, vestingDuration);
     }
 
     function owner() public view returns (address) {
@@ -27,9 +33,10 @@ contract VestingContractTest is Test {
     function test_Initialize() public {
         assertEq(vesting.masterChef(), address(this), "test_Initialize::1");
         assertEq(address(vesting.token()), address(token), "test_Initialize::2");
-        assertEq(vesting.start(), block.timestamp + 365 days, "test_Initialize::3");
-        assertEq(vesting.duration(), 365 days, "test_Initialize::4");
-        assertEq(vesting.end(), block.timestamp + 2 * 365 days, "test_Initialize::5");
+        assertEq(vesting.start(), start, "test_Initialize::3");
+        assertEq(vesting.cliffDuration(), cliffDuration, "test_Initialize::4");
+        assertEq(vesting.vestingDuration(), vestingDuration, "test_Initialize::5");
+        assertEq(vesting.end(), start + vestingDuration, "test_Initialize::6");
         assertEq(vesting.beneficiary(), address(0), "test_Initialize::6");
         assertEq(vesting.released(), 0, "test_Initialize::7");
         assertEq(vesting.releasable(), 0, "test_Initialize::8");
@@ -49,10 +56,10 @@ contract VestingContractTest is Test {
     }
 
     function test_Release() public {
-        MockERC20(address(token)).mint(address(vesting), 365e18);
+        MockERC20(address(token)).mint(address(vesting), total);
         vesting.setBeneficiary(alice);
 
-        vm.warp(block.timestamp + 365 days - 1);
+        vm.warp(start - 1);
 
         assertEq(vesting.releasable(), 0, "test_Release::1");
 
@@ -65,9 +72,9 @@ contract VestingContractTest is Test {
         assertEq(vesting.released(), 0, "test_Release::2");
         assertEq(vesting.releasable(), 0, "test_Release::3");
         assertEq(token.balanceOf(alice), 0, "test_Release::4");
-        assertEq(token.balanceOf(address(vesting)), 365e18, "test_Release::5");
+        assertEq(token.balanceOf(address(vesting)), total, "test_Release::5");
 
-        vm.warp(block.timestamp + 1);
+        vm.warp(start);
 
         assertEq(vesting.releasable(), 0, "test_Release::6");
 
@@ -77,98 +84,100 @@ contract VestingContractTest is Test {
         assertEq(vesting.released(), 0, "test_Release::7");
         assertEq(vesting.releasable(), 0, "test_Release::8");
         assertEq(token.balanceOf(alice), 0, "test_Release::9");
-        assertEq(token.balanceOf(address(vesting)), 365e18, "test_Release::10");
+        assertEq(token.balanceOf(address(vesting)), total, "test_Release::10");
 
-        vm.warp(block.timestamp + 1 days);
+        vm.warp(start + cliffDuration);
 
-        assertEq(vesting.releasable(), 1e18, "test_Release::11");
+        assertEq(vesting.releasable(), 0, "test_Release::11");
 
         vm.prank(alice);
         vesting.release();
 
-        assertEq(vesting.released(), 1e18, "test_Release::12");
+        assertEq(vesting.released(), 0, "test_Release::12");
         assertEq(vesting.releasable(), 0, "test_Release::13");
-        assertEq(token.balanceOf(alice), 1e18, "test_Release::14");
-        assertEq(token.balanceOf(address(vesting)), 364e18, "test_Release::15");
+        assertEq(token.balanceOf(alice), 0, "test_Release::14");
+        assertEq(token.balanceOf(address(vesting)), total, "test_Release::15");
 
-        vm.warp(block.timestamp + 364 days);
+        vm.warp(start + cliffDuration + 1);
 
-        assertEq(vesting.releasable(), 364e18, "test_Release::16");
+        uint256 expectedReleasable = (cliffDuration + 1) * total / vestingDuration;
+
+        assertEq(vesting.releasable(), expectedReleasable, "test_Release::16");
 
         vm.prank(alice);
         vesting.release();
 
-        assertEq(vesting.released(), 365e18, "test_Release::17");
+        assertEq(vesting.released(), expectedReleasable, "test_Release::17");
         assertEq(vesting.releasable(), 0, "test_Release::18");
-        assertEq(token.balanceOf(alice), 365e18, "test_Release::19");
-        assertEq(token.balanceOf(address(vesting)), 0, "test_Release::20");
+        assertEq(token.balanceOf(alice), expectedReleasable, "test_Release::19");
+        assertEq(token.balanceOf(address(vesting)), total - expectedReleasable, "test_Release::20");
 
-        vm.warp(block.timestamp + 1 days);
+        vm.warp(start + vestingDuration);
 
-        assertEq(vesting.releasable(), 0, "test_Release::21");
+        assertEq(vesting.releasable(), total - expectedReleasable, "test_Release::21");
 
         vm.prank(alice);
         vesting.release();
 
-        assertEq(vesting.released(), 365e18, "test_Release::22");
+        assertEq(vesting.released(), total, "test_Release::22");
         assertEq(vesting.releasable(), 0, "test_Release::23");
-        assertEq(token.balanceOf(alice), 365e18, "test_Release::24");
+        assertEq(token.balanceOf(alice), total, "test_Release::24");
         assertEq(token.balanceOf(address(vesting)), 0, "test_Release::25");
 
-        MockERC20(address(token)).mint(address(vesting), 365e18);
+        MockERC20(address(token)).mint(address(vesting), total);
 
-        assertEq(vesting.releasable(), 365e18, "test_Release::26");
+        assertEq(vesting.releasable(), total, "test_Release::26");
 
         vm.prank(alice);
         vesting.release();
 
-        assertEq(vesting.released(), 730e18, "test_Release::27");
+        assertEq(vesting.released(), 2 * total, "test_Release::27");
         assertEq(vesting.releasable(), 0, "test_Release::28");
-        assertEq(token.balanceOf(alice), 730e18, "test_Release::29");
+        assertEq(token.balanceOf(alice), 2 * total, "test_Release::29");
         assertEq(token.balanceOf(address(vesting)), 0, "test_Release::30");
     }
 
     function test_ReleaseMoreTokenInMiddle() public {
-        MockERC20(address(token)).mint(address(vesting), 365e18);
+        MockERC20(address(token)).mint(address(vesting), total);
         vesting.setBeneficiary(alice);
 
-        vm.warp(block.timestamp + 365 days + (365 days / 2));
+        vm.warp(start + (vestingDuration / 2));
 
-        assertEq(vesting.releasable(), 365e18 / 2, "test_ReleaseMoreTokenInMiddle::1");
-
-        vm.prank(alice);
-        vesting.release();
-
-        MockERC20(address(token)).mint(address(vesting), 365e18);
-
-        assertEq(vesting.releasable(), 365e18 / 2, "test_ReleaseMoreTokenInMiddle::2");
+        assertEq(vesting.releasable(), total / 2, "test_ReleaseMoreTokenInMiddle::1");
 
         vm.prank(alice);
         vesting.release();
 
-        assertEq(vesting.released(), 365e18, "test_ReleaseMoreTokenInMiddle::3");
+        MockERC20(address(token)).mint(address(vesting), total);
+
+        assertEq(vesting.releasable(), total / 2, "test_ReleaseMoreTokenInMiddle::2");
+
+        vm.prank(alice);
+        vesting.release();
+
+        assertEq(vesting.released(), total, "test_ReleaseMoreTokenInMiddle::3");
         assertEq(vesting.releasable(), 0, "test_ReleaseMoreTokenInMiddle::4");
-        assertEq(token.balanceOf(alice), 365e18, "test_ReleaseMoreTokenInMiddle::5");
-        assertEq(token.balanceOf(address(vesting)), 365e18, "test_ReleaseMoreTokenInMiddle::6");
+        assertEq(token.balanceOf(alice), total, "test_ReleaseMoreTokenInMiddle::5");
+        assertEq(token.balanceOf(address(vesting)), total, "test_ReleaseMoreTokenInMiddle::6");
 
-        vm.warp(block.timestamp + 365 days + (365 days / 2));
+        vm.warp(start + vestingDuration);
 
-        assertEq(vesting.releasable(), 365e18, "test_ReleaseMoreTokenInMiddle::7");
+        assertEq(vesting.releasable(), total, "test_ReleaseMoreTokenInMiddle::7");
 
         vm.prank(alice);
         vesting.release();
 
-        assertEq(vesting.released(), 730e18, "test_ReleaseMoreTokenInMiddle::8");
+        assertEq(vesting.released(), 2 * total, "test_ReleaseMoreTokenInMiddle::8");
         assertEq(vesting.releasable(), 0, "test_ReleaseMoreTokenInMiddle::9");
-        assertEq(token.balanceOf(alice), 730e18, "test_ReleaseMoreTokenInMiddle::10");
+        assertEq(token.balanceOf(alice), 2 * total, "test_ReleaseMoreTokenInMiddle::10");
         assertEq(token.balanceOf(address(vesting)), 0, "test_ReleaseMoreTokenInMiddle::11");
     }
 
     function test_RevokeBeforeStart() public {
-        MockERC20(address(token)).mint(address(vesting), 365e18);
+        MockERC20(address(token)).mint(address(vesting), total);
         vesting.setBeneficiary(alice);
 
-        vm.warp(block.timestamp + 365 days - 1);
+        vm.warp(start - 1);
 
         assertEq(vesting.revoked(), false, "test_RevokeBeforeStart::1");
 
@@ -180,73 +189,105 @@ contract VestingContractTest is Test {
         assertEq(vesting.vestedAmount(block.timestamp), 0, "test_RevokeBeforeStart::5");
         assertEq(token.balanceOf(alice), 0, "test_RevokeBeforeStart::6");
         assertEq(token.balanceOf(address(vesting)), 0, "test_RevokeBeforeStart::7");
-        assertEq(token.balanceOf(address(this)), 365e18, "test_RevokeBeforeStart::8");
+        assertEq(token.balanceOf(address(this)), total, "test_RevokeBeforeStart::8");
     }
 
-    function test_RevokeAfterStart() public {
-        MockERC20(address(token)).mint(address(vesting), 365e18);
+    function test_Fuzz_RevokeAfterStartBeforeCliff(uint256 t0) public {
+        t0 = bound(t0, start, start + cliffDuration);
+
+        MockERC20(address(token)).mint(address(vesting), total);
         vesting.setBeneficiary(alice);
 
-        vm.warp(block.timestamp + 365 days + 10 days);
+        vm.warp(t0);
 
         assertEq(vesting.revoked(), false, "test_RevokeAfterStart::1");
 
         vesting.revoke();
 
         assertEq(vesting.released(), 0, "test_RevokeAfterStart::2");
-        assertEq(vesting.releasable(), 10e18, "test_RevokeAfterStart::3");
-        assertEq(vesting.vestedAmount(block.timestamp), 10e18, "test_RevokeAfterStart::4");
+        assertEq(vesting.releasable(), 0, "test_RevokeAfterStart::3");
+        assertEq(vesting.vestedAmount(block.timestamp), 0, "test_RevokeAfterStart::4");
         assertEq(token.balanceOf(alice), 0, "test_RevokeAfterStart::5");
-        assertEq(token.balanceOf(address(vesting)), 10e18, "test_RevokeAfterStart::6");
-        assertEq(token.balanceOf(address(this)), 355e18, "test_RevokeAfterStart::7");
+        assertEq(token.balanceOf(address(vesting)), 0, "test_RevokeAfterStart::6");
+        assertEq(token.balanceOf(address(this)), total, "test_RevokeAfterStart::7");
 
         vm.prank(alice);
         vesting.release();
 
         assertEq(vesting.revoked(), true, "test_RevokeAfterStart::8");
-        assertEq(vesting.released(), 10e18, "test_RevokeAfterStart::9");
+        assertEq(vesting.released(), 0, "test_RevokeAfterStart::9");
         assertEq(vesting.releasable(), 0, "test_RevokeAfterStart::10");
-        assertEq(vesting.vestedAmount(block.timestamp), 10e18, "test_RevokeAfterStart::11");
-        assertEq(token.balanceOf(alice), 10e18, "test_RevokeAfterStart::12");
+        assertEq(vesting.vestedAmount(block.timestamp), 0, "test_RevokeAfterStart::11");
+        assertEq(token.balanceOf(alice), 0, "test_RevokeAfterStart::12");
         assertEq(token.balanceOf(address(vesting)), 0, "test_RevokeAfterStart::13");
-        assertEq(token.balanceOf(address(this)), 355e18, "test_RevokeAfterStart::14");
+        assertEq(token.balanceOf(address(this)), total, "test_RevokeAfterStart::14");
+    }
+
+    function test_Fuzz_RevokeAfterStartAfterCliff(uint256 t0) public {
+        t0 = bound(t0, start + cliffDuration + 1, start + vestingDuration);
+
+        MockERC20(address(token)).mint(address(vesting), total);
+        vesting.setBeneficiary(alice);
+
+        vm.warp(t0);
+
+        assertEq(vesting.revoked(), false, "test_RevokeAfterStart::1");
+
+        vesting.revoke();
+
+        uint256 expectedReleasable = (t0 - start) * total / vestingDuration;
+
+        assertEq(vesting.released(), 0, "test_RevokeAfterStart::2");
+        assertEq(vesting.releasable(), expectedReleasable, "test_RevokeAfterStart::3");
+        assertEq(vesting.vestedAmount(block.timestamp), expectedReleasable, "test_RevokeAfterStart::4");
+        assertEq(token.balanceOf(alice), 0, "test_RevokeAfterStart::5");
+        assertEq(token.balanceOf(address(vesting)), expectedReleasable, "test_RevokeAfterStart::6");
+        assertEq(token.balanceOf(address(this)), total - expectedReleasable, "test_RevokeAfterStart::7");
+
+        vm.prank(alice);
+        vesting.release();
+
+        assertEq(vesting.revoked(), true, "test_RevokeAfterStart::8");
+        assertEq(vesting.released(), expectedReleasable, "test_RevokeAfterStart::9");
+        assertEq(vesting.releasable(), 0, "test_RevokeAfterStart::10");
+        assertEq(vesting.vestedAmount(block.timestamp), expectedReleasable, "test_RevokeAfterStart::11");
+        assertEq(token.balanceOf(alice), expectedReleasable, "test_RevokeAfterStart::12");
+        assertEq(token.balanceOf(address(vesting)), 0, "test_RevokeAfterStart::13");
+        assertEq(token.balanceOf(address(this)), total - expectedReleasable, "test_RevokeAfterStart::14");
     }
 
     function test_RevokeAfterEnd() public {
-        MockERC20(address(token)).mint(address(vesting), 365e18);
+        MockERC20(address(token)).mint(address(vesting), total);
         vesting.setBeneficiary(alice);
 
-        vm.warp(block.timestamp + 2 * 365 days + 1);
+        vm.warp(start + vestingDuration + 1);
 
         assertEq(vesting.revoked(), false, "test_RevokeAfterEnd::1");
 
         vesting.revoke();
 
         assertEq(vesting.released(), 0, "test_RevokeAfterEnd::2");
-        assertEq(vesting.releasable(), 365e18, "test_RevokeAfterEnd::3");
-        assertEq(vesting.vestedAmount(block.timestamp), 365e18, "test_RevokeAfterEnd::4");
+        assertEq(vesting.releasable(), total, "test_RevokeAfterEnd::3");
+        assertEq(vesting.vestedAmount(block.timestamp), total, "test_RevokeAfterEnd::4");
         assertEq(token.balanceOf(alice), 0, "test_RevokeAfterEnd::5");
-        assertEq(token.balanceOf(address(vesting)), 365e18, "test_RevokeAfterEnd::6");
+        assertEq(token.balanceOf(address(vesting)), total, "test_RevokeAfterEnd::6");
         assertEq(token.balanceOf(address(this)), 0, "test_RevokeAfterEnd::7");
 
         vm.prank(alice);
         vesting.release();
 
         assertEq(vesting.revoked(), true, "test_RevokeAfterEnd::8");
-        assertEq(vesting.released(), 365e18, "test_RevokeAfterEnd::9");
+        assertEq(vesting.released(), total, "test_RevokeAfterEnd::9");
         assertEq(vesting.releasable(), 0, "test_RevokeAfterEnd::10");
-        assertEq(vesting.vestedAmount(block.timestamp), 365e18, "test_RevokeAfterEnd::11");
-        assertEq(token.balanceOf(alice), 365e18, "test_RevokeAfterEnd::12");
+        assertEq(vesting.vestedAmount(block.timestamp), total, "test_RevokeAfterEnd::11");
+        assertEq(token.balanceOf(alice), total, "test_RevokeAfterEnd::12");
         assertEq(token.balanceOf(address(vesting)), 0, "test_RevokeAfterEnd::13");
         assertEq(token.balanceOf(address(this)), 0, "test_RevokeAfterEnd::14");
     }
 
     function test_Fuzz_Revoke(uint256 t0, uint256 t1) public {
-        t0 = bound(t0, 0, 100 days - 1);
-        t1 = bound(t1, t0 + 1, 100 days);
-
-        uint256 start = block.timestamp + 365 days;
-        uint256 total = 100e18;
+        t0 = bound(t0, 0, vestingDuration - 1);
+        t1 = bound(t1, t0 + 1, vestingDuration);
 
         MockERC20(address(token)).mint(address(vesting), total);
         vesting.setBeneficiary(alice);
@@ -258,7 +299,7 @@ contract VestingContractTest is Test {
         vm.prank(alice);
         vesting.release();
 
-        uint256 released0 = t0 * total / 365 days;
+        uint256 released0 = t0 > cliffDuration ? t0 * total / vestingDuration : 0;
 
         assertEq(vesting.revoked(), false, "test_Fuzz_Revoke::2");
         assertEq(vesting.released(), released0, "test_Fuzz_Revoke::3");
@@ -270,7 +311,7 @@ contract VestingContractTest is Test {
 
         vm.warp(start + t1);
 
-        uint256 released1 = t1 * total / 365 days;
+        uint256 released1 = t1 > cliffDuration ? t1 * total / vestingDuration : 0;
 
         vesting.revoke();
 


### PR DESCRIPTION
This PR aims to add a cliff to the vesting contracts.
The vesting still vests from `start` to `start + duration`, but tokens can only be claimed after `start + cliff`