### PR TITLE
Update rewarder

### DIFF
--- a/src/MoeLens.sol
+++ b/src/MoeLens.sol
@@ -218,14 +218,7 @@ contract MoeLens {
                 reward = r;
             } catch {}
 
-            uint256 remainingReward;
-            uint256 version;
-            try rewarder.getRemainingReward() returns (uint256 remaining) {
-                remainingReward = remaining;
-                version = 2;
-            } catch {
-                version = 1;
-            }
+            (uint256 remainingReward, uint256 version) = _getRemainingRewardAndVersion(address(rewarder));
 
             farm.rewarder = Rewarder({
                 version: version,
@@ -361,14 +354,7 @@ contract MoeLens {
                 } catch {}
             }
 
-            uint256 remainingReward;
-            uint256 version;
-            try bribe.getRemainingReward() returns (uint256 remaining) {
-                remainingReward = remaining;
-                version = 2;
-            } catch {
-                version = 1;
-            }
+            (uint256 remainingReward, uint256 version) = _getRemainingRewardAndVersion(address(bribe));
 
             vote.rewarder = Rewarder({
                 version: version,
@@ -418,14 +404,7 @@ contract MoeLens {
             reward = r;
         } catch {}
 
-        uint256 remainingReward;
-        uint256 version;
-        try rewarderContract.getRemainingReward() returns (uint256 remaining) {
-            remainingReward = remaining;
-            version = 2;
-        } catch {
-            version = 1;
-        }
+        (uint256 remainingReward, uint256 version) = _getRemainingRewardAndVersion(address(rewarderContract));
 
         rewarder = Rewarder({
             version: version,
@@ -459,5 +438,20 @@ contract MoeLens {
             userStaked: _joeStaking.getDeposit(user),
             userReward: reward
         });
+    }
+
+    function _getRemainingRewardAndVersion(address rewarder)
+        private
+        view
+        returns (uint256 remainingReward, uint256 version)
+    {
+        (, bytes memory data) = rewarder.staticcall(abi.encodeWithSelector(IBaseRewarder.getRemainingReward.selector));
+
+        if (data.length > 31) {
+            remainingReward = abi.decode(data, (uint256));
+            version = 2;
+        } else {
+            version = 1;
+        }
     }
 }

--- a/src/interfaces/IBaseRewarder.sol
+++ b/src/interfaces/IBaseRewarder.sol
@@ -46,10 +46,13 @@ interface IBaseRewarder {
 
     function initialize(address initialOwner) external;
 
-    function setRewardPerSecond(uint256 maxRewardPerSecond, uint256 expectedDuration) external;
+    function setRewardPerSecond(uint256 maxRewardPerSecond, uint256 expectedDuration)
+        external
+        returns (uint256 rewardPerSecond);
 
     function setRewarderParameters(uint256 maxRewardPerSecond, uint256 startTimestamp, uint256 expectedDuration)
-        external;
+        external
+        returns (uint256 rewardPerSecond);
 
     function stop() external;
 

--- a/src/interfaces/IBaseRewarder.sol
+++ b/src/interfaces/IBaseRewarder.sol
@@ -10,7 +10,7 @@ interface IBaseRewarder {
     error BaseRewarder__AlreadyStopped();
     error BaseRewarder__NotNativeRewarder();
     error BaseRewarder__ZeroAmount();
-    error BaseRewarder__InsufficientReward(uint256 remainingReward, uint256 expectedReward);
+    error BaseRewarder__ZeroReward();
     error BaseRewarder__InvalidDuration();
     error BaseRewarder__InvalidPid(uint256 pid);
     error BaseRewarder__InvalidStartTimestamp(uint256 startTimestamp);
@@ -46,9 +46,9 @@ interface IBaseRewarder {
 
     function initialize(address initialOwner) external;
 
-    function setRewardPerSecond(uint256 rewardPerSecond, uint256 expectedDuration) external;
+    function setRewardPerSecond(uint256 maxRewardPerSecond, uint256 expectedDuration) external;
 
-    function setRewarderParameters(uint256 rewardPerSecond, uint256 startTimestamp, uint256 expectedDuration)
+    function setRewarderParameters(uint256 maxRewardPerSecond, uint256 startTimestamp, uint256 expectedDuration)
         external;
 
     function stop() external;

--- a/src/interfaces/IBaseRewarder.sol
+++ b/src/interfaces/IBaseRewarder.sol
@@ -35,6 +35,8 @@ interface IBaseRewarder {
         view
         returns (IERC20 token, uint256 rewardPerSecond, uint256 lastUpdateTimestamp, uint256 endTimestamp);
 
+    function getRemainingReward() external view returns (uint256);
+
     function getPendingReward(address account, uint256 balance, uint256 totalSupply)
         external
         view

--- a/src/rewarders/BaseRewarder.sol
+++ b/src/rewarders/BaseRewarder.sol
@@ -198,7 +198,8 @@ abstract contract BaseRewarder is Ownable2StepUpgradeable, Clone, IBaseRewarder 
     /**
      * @dev Transfers any remaining tokens to the specified account.
      * If the token is the reward token, only the excess amount will be transferred.
-     * If the rewarder is stopped, the entire balance will be transferred.
+     * Even if the rewarder is stopped, the unclaimed rewards will not be transferred; unless the total supply is 0.
+     * (for example if there is leftover because of emergency withdrawal or roundings).
      * @param token The token to transfer.
      * @param account The account to transfer the tokens to.
      */

--- a/src/rewarders/BaseRewarder.sol
+++ b/src/rewarders/BaseRewarder.sol
@@ -146,13 +146,16 @@ abstract contract BaseRewarder is Ownable2StepUpgradeable, Clone, IBaseRewarder 
      * @param maxRewardPerSecond The maximum reward per second.
      * @param startTimestamp The start timestamp.
      * @param expectedDuration The expected duration of the reward distribution.
+     * @return rewardPerSecond The actual reward per second.
      */
     function setRewarderParameters(uint256 maxRewardPerSecond, uint256 startTimestamp, uint256 expectedDuration)
         public
         virtual
+        override
         onlyOwner
+        returns (uint256 rewardPerSecond)
     {
-        _setRewardParameters(maxRewardPerSecond, startTimestamp, expectedDuration);
+        return _setRewardParameters(maxRewardPerSecond, startTimestamp, expectedDuration);
     }
 
     /**
@@ -160,17 +163,19 @@ abstract contract BaseRewarder is Ownable2StepUpgradeable, Clone, IBaseRewarder 
      * If the expected duration is 0, the reward distribution will be stopped.
      * @param maxRewardPerSecond The maximum reward per second.
      * @param expectedDuration The expected duration of the reward distribution.
+     * @return rewardPerSecond The actual reward per second.
      */
     function setRewardPerSecond(uint256 maxRewardPerSecond, uint256 expectedDuration)
         public
         virtual
         override
         onlyOwner
+        returns (uint256 rewardPerSecond)
     {
         uint256 lastUpdateTimestamp = _rewarder.lastUpdateTimestamp;
         uint256 startTimestamp = lastUpdateTimestamp > block.timestamp ? lastUpdateTimestamp : block.timestamp;
 
-        _setRewardParameters(maxRewardPerSecond, startTimestamp, expectedDuration);
+        return _setRewardParameters(maxRewardPerSecond, startTimestamp, expectedDuration);
     }
 
     /**
@@ -316,10 +321,12 @@ abstract contract BaseRewarder is Ownable2StepUpgradeable, Clone, IBaseRewarder 
      * @param maxRewardPerSecond The maximum reward per second.
      * @param startTimestamp The start timestamp.
      * @param expectedDuration The expected duration of the reward distribution.
+     * @return rewardPerSecond The actual reward per second.
      */
     function _setRewardParameters(uint256 maxRewardPerSecond, uint256 startTimestamp, uint256 expectedDuration)
         internal
         virtual
+        returns (uint256 rewardPerSecond)
     {
         if (startTimestamp < block.timestamp) revert BaseRewarder__InvalidStartTimestamp(startTimestamp);
         if (_isStopped) revert BaseRewarder__Stopped();
@@ -335,8 +342,7 @@ abstract contract BaseRewarder is Ownable2StepUpgradeable, Clone, IBaseRewarder 
         uint256 remainingReward = _balanceOfThis(_token()) - totalUnclaimedRewards;
         uint256 maxExpectedReward = maxRewardPerSecond * expectedDuration;
 
-        uint256 rewardPerSecond =
-            maxExpectedReward > remainingReward ? remainingReward / expectedDuration : maxRewardPerSecond;
+        rewardPerSecond = maxExpectedReward > remainingReward ? remainingReward / expectedDuration : maxRewardPerSecond;
         uint256 expectedReward = rewardPerSecond * expectedDuration;
 
         if (expectedDuration != 0 && expectedReward == 0) revert BaseRewarder__ZeroReward();

--- a/src/rewarders/BaseRewarder.sol
+++ b/src/rewarders/BaseRewarder.sol
@@ -102,6 +102,19 @@ abstract contract BaseRewarder is Ownable2StepUpgradeable, Clone, IBaseRewarder 
     }
 
     /**
+     * @dev Returns the remaining reward.
+     * @return The remaining reward.
+     */
+    function getRemainingReward() public view virtual override returns (uint256) {
+        uint256 totalSupply = _getTotalSupply();
+        uint256 totalRewards = _rewarder.getTotalRewards(_rewardsPerSecond, _endTimestamp, totalSupply);
+
+        uint256 totalUnclaimedRewards = _totalUnclaimedRewards + totalRewards;
+
+        return _balanceOfThis(_token()) - totalUnclaimedRewards;
+    }
+
+    /**
      * @dev Returns the pending rewards for a given account.
      * @param account The account to check for pending rewards.
      * @param balance The balance of the account.

--- a/test/MasterChefRewarder.t.sol
+++ b/test/MasterChefRewarder.t.sol
@@ -98,21 +98,23 @@ contract MasterChefRewarderTest is Test {
 
         MockERC20(address(rewardToken)).mint(address(rewarder), 100e18);
 
-        rewarder.setRewardPerSecond(1e18, 100);
+        uint256 actualRewardPerSecond = rewarder.setRewardPerSecond(1e18, 100);
 
         (, uint256 rewardPerSecond,, uint256 endTimestamp) = rewarder.getRewarderParameter();
 
         assertEq(rewardPerSecond, 1e18, "test_SetRewardPerSecond::1");
-        assertEq(endTimestamp, block.timestamp + 100, "test_SetRewardPerSecond::2");
+        assertEq(actualRewardPerSecond, 1e18, "test_SetRewardPerSecond::2");
+        assertEq(endTimestamp, block.timestamp + 100, "test_SetRewardPerSecond::3");
 
         vm.warp(block.timestamp + 50);
 
-        rewarder.setRewardPerSecond(1e18, 100);
+        actualRewardPerSecond = rewarder.setRewardPerSecond(1e18, 100);
 
         (, rewardPerSecond,, endTimestamp) = rewarder.getRewarderParameter();
 
-        assertEq(rewardPerSecond, 0.5e18, "test_SetRewardPerSecond::3");
-        assertEq(endTimestamp, block.timestamp + 100, "test_SetRewardPerSecond::4");
+        assertEq(rewardPerSecond, 0.5e18, "test_SetRewardPerSecond::4");
+        assertEq(actualRewardPerSecond, 0.5e18, "test_SetRewardPerSecond::5");
+        assertEq(endTimestamp, block.timestamp + 100, "test_SetRewardPerSecond::6");
 
         rewarder.setRewardPerSecond(0, 0);
 

--- a/test/MoeLens.t.sol
+++ b/test/MoeLens.t.sol
@@ -1,0 +1,50 @@
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+
+import "../script/mantle/Parameters.sol";
+import "../script/mantle/Addresses.sol";
+
+import "../src/MoeLens.sol";
+import "../src/rewarders/VeMoeRewarder.sol";
+
+contract UpgradeTest is Test {
+    MoeLens moeLens;
+
+    function setUp() public {
+        setChain(
+            Parameters.chainAlias,
+            StdChains.ChainData({name: Parameters.chainName, chainId: Parameters.chainId, rpcUrl: Parameters.rpcUrl})
+        );
+
+        vm.createSelectFork(StdChains.getChain(Parameters.chainAlias).rpcUrl, 50344826);
+
+        moeLens = new MoeLens(
+            IMasterChef(Addresses.masterChefProxy), IJoeStaking(Addresses.joeStakingProxy), Parameters.nativeSymbol
+        );
+    }
+
+    function test_GetVersion() public {
+        MoeLens.Rewarder memory rewarder = moeLens.getVeMoeRewarderDataAt(218);
+
+        assertEq(rewarder.version, 1, "test_GetVersion::1");
+
+        VeMoeRewarder imp = new VeMoeRewarder(Addresses.veMoeProxy);
+
+        vm.prank(Addresses.devMultisig);
+        IRewarderFactory(Addresses.rewarderFactoryProxy).setRewarderImplementation(
+            IRewarderFactory.RewarderType.VeMoeRewarder, IBaseRewarder(imp)
+        );
+
+        IRewarderFactory(Addresses.rewarderFactoryProxy).createRewarder(
+            IRewarderFactory.RewarderType.VeMoeRewarder, IERC20(address(0)), 0
+        );
+        uint256 length = IRewarderFactory(Addresses.rewarderFactoryProxy).getRewarderCount(
+            IRewarderFactory.RewarderType.VeMoeRewarder
+        );
+
+        rewarder = moeLens.getVeMoeRewarderDataAt(length - 1);
+
+        assertEq(rewarder.version, 2, "test_GetVersion::2");
+    }
+}


### PR DESCRIPTION
The PR aims to add a `getRemainingAmount` function in the rewarders to allow reuse of non-empty rewarder.
Furthermore, change the fixed `rewardPerSecond` to `maxRewardPerSecond` to allow some divergence between what is sent by the user and what will be used by the rewarder (because time will pass between the input and the transaction added to a block)